### PR TITLE
[CREStereo] Remove unused parameters from forward()

### DIFF
--- a/nets/crestereo.py
+++ b/nets/crestereo.py
@@ -81,7 +81,7 @@ class CREStereo(nn.Module):
         zero_flow = torch.cat((_x, _y), dim=1).to(fmap.device)
         return zero_flow
 
-    def forward(self, image1, image2, flow_init=None, iters=10, upsample=True, test_mode=False):
+    def forward(self, image1, image2, flow_init=None, iters=10):
         """ Estimate optical flow between pair of frames """
 
         image1 = 2 * (image1 / 255.0) - 1.0


### PR DESCRIPTION
The parameters `upsample` and `test_mode` are not used in this function. `test_mode` is determined from the class attribute `self.test_mode`.